### PR TITLE
fix(release): restore unsigned manual-download contingency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
       windows_mode: ${{ steps.policy.outputs.windows_mode }}
       macos_mode: ${{ steps.policy.outputs.macos_mode }}
       signing_required: ${{ steps.policy.outputs.signing_required }}
+      updater_mode: ${{ steps.policy.outputs.updater_mode }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -287,6 +288,11 @@ jobs:
           echo "macos_mode=$(echo "${POLICY}" | node -e "process.stdin.on('data',d=>{const p=JSON.parse(d);process.stdout.write(p.macos)})")" >> "$GITHUB_OUTPUT"
           W="$(echo "${POLICY}" | node -e "process.stdin.on('data',d=>{const p=JSON.parse(d);process.stdout.write(String(p.windows==='signed'||p.macos==='signed'))})")"
           echo "signing_required=${W}" >> "$GITHUB_OUTPUT"
+          if [[ "${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}" == "true" ]]; then
+            echo "updater_mode=signed" >> "$GITHUB_OUTPUT"
+          else
+            echo "updater_mode=manual-only" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Report policy outcome
         shell: bash
@@ -298,19 +304,20 @@ jobs:
             echo "- macOS: **${{ steps.policy.outputs.macos_mode }}**"
             echo "- Channel: ${{ needs.preflight.outputs.channel }}"
             echo "- RELEASE_EXPECT_SIGNED: ${{ vars.RELEASE_EXPECT_SIGNED || '(unset)' }}"
+            echo "- Updater: **${{ steps.policy.outputs.updater_mode }}**"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Require protected updater signing key
+      - name: Record manual-update contingency
         shell: bash
         env:
           TAURI_KEY_PRESENT: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
         run: |
           if [[ "${TAURI_KEY_PRESENT}" != "true" ]]; then
-            echo "::error::TAURI_SIGNING_PRIVATE_KEY is required for release updater artifacts."
-            echo "The updater public key is embedded in the app; publishing an unsigned .sig/feed would be fail-open."
-            exit 1
+            echo "::warning::Updater signing key is absent; publishing manual-download installers without an updater feed."
+            echo "Platform signedness remains independently governed by RELEASE_EXPECT_SIGNED."
+          else
+            echo "Tauri updater signing key present (value never printed)."
           fi
-          echo "Tauri updater signing key present (value never printed)."
 
   # ── 3. Platform bundles on native runners ───────────────────────────────────
   bundle:
@@ -657,7 +664,8 @@ jobs:
             --bundle-dir "${TAURI_BUNDLE_DIR}" \
             --out dist/release \
             --os ${{ matrix.os_slug }} \
-            --arch ${{ matrix.arch_slug }}
+            --arch ${{ matrix.arch_slug }} \
+            --updater-signatures "${{ needs.signing-preflight.outputs.updater_mode == 'signed' }}"
         shell: bash
 
       # Platform-specific SBOM: the bundle contents differ per platform (the
@@ -988,7 +996,7 @@ jobs:
   # Any step failing stops the release before a draft exists.
   verify:
     name: Verify, attest and finalize
-    needs: [preflight, bundle, package-smoke, platform-smoke]
+    needs: [preflight, signing-preflight, bundle, package-smoke, platform-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -1044,6 +1052,7 @@ jobs:
             --expect-signed "${EXPECT}"
 
       - name: Generate signed updater feed
+        if: needs.signing-preflight.outputs.updater_mode == 'signed'
         shell: bash
         run: |
           node scripts/release/generate-updater-feed.mjs \
@@ -1051,6 +1060,16 @@ jobs:
             --version '${{ needs.preflight.outputs.version }}' \
             --channel '${{ needs.preflight.outputs.channel }}' \
             --base-url 'https://github.com/K-Arthur/varve/releases/download/${{ needs.preflight.outputs.tag }}'
+
+      - name: Record manual update fallback
+        if: needs.signing-preflight.outputs.updater_mode != 'signed'
+        run: |
+          {
+            echo "### Manual update fallback"
+            echo ""
+            echo "Updater signatures were not available; no updater feed was generated."
+            echo "Installers remain available for manual download and are labelled with their verified platform signing state."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # The combined SBOM describes the whole multi-platform release; its scope
       # is declared explicitly in its metadata. Platform-specific SBOMs arrived

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -54,8 +54,8 @@ tag v0.1.0
    │
    ├── preflight          tag == version == changelog entry, or stop
    ├── gate               lint, typecheck, tests, clippy, cargo test
-   ├── signing-preflight  credentials validated BEFORE any build (fail-closed)
-   ├── bundle             native runners; sign; verify signatures on the
+   ├── signing-preflight  resolve signed or manual-download contingency
+   ├── bundle             native runners; sign when configured; verify the
    │                      artifact bytes (signing-report-*.json); collect; hash
    ├── package-smoke      clean-container install + headless launch (Linux)
    ├── platform-smoke     install/mount + launch + uninstall (Win/macOS)
@@ -67,6 +67,12 @@ tag v0.1.0
 
 A tag never publishes anything by itself. See
 [.github/workflows/release.yml](../../.github/workflows/release.yml).
+
+When `RELEASE_EXPECT_SIGNED` is unset and signing credentials are not yet
+available, the release remains publishable as an explicitly unsigned,
+manual-download release. The workflow omits updater assets until the updater
+private key exists; it never silently downgrades a release that explicitly
+requires signatures.
 
 ## Before you touch any of this
 

--- a/docs/release/ci-secrets.md
+++ b/docs/release/ci-secrets.md
@@ -18,13 +18,20 @@ this repository.**
 
 ---
 
-## 1. Secrets currently required: updater key for release builds
+## 1. Optional signing and manual-download contingency
 
-The release workflow now produces Tauri updater artifacts (`.sig` files and
-static channel feeds), so `TAURI_SIGNING_PRIVATE_KEY` is required before any
-bundle is built. The protected signing-preflight job fails closed when it is
-absent; it never prints the value. Platform code-signing credentials remain
-separate and are required according to the signing policy below.
+The release workflow supports two honest modes. With the signing credentials
+below, it produces cryptographically verified platform-signed installers and,
+when the updater key is present, signed Tauri updater artifacts. When those
+credentials are absent and `RELEASE_EXPECT_SIGNED` is unset, the documented
+zero-cost contingency builds and publishes manual-download installers with
+`signed: false` metadata and OS-specific warnings. It does not generate an
+updater feed, and it never labels an unsigned artifact as signed.
+
+`RELEASE_EXPECT_SIGNED=true` is the explicit fail-closed switch: missing
+platform signing credentials stop the release before packaging. The updater
+key is independently optional; without it, existing clients remain on manual
+updates until the key is provisioned.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "pnpm test:ci:tools && vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:ci:tools": "node scripts/ci-debug.test.mjs && node scripts/ci-health.test.mjs && node scripts/pin-github-actions.test.mjs && node scripts/validate-workflows.test.mjs && node scripts/release/release-pipeline.test.mjs && node scripts/release/signing-policy.test.mjs && node scripts/secret-scan.test.mjs && node scripts/security/workflow-policy.test.mjs && node scripts/security/validate-client-env.test.mjs && node scripts/security/import-boundaries.test.mjs && node scripts/security/dependency-hardening.test.mjs && bash scripts/test-ci-shell-scripts.sh",
+    "test:ci:tools": "node scripts/ci-debug.test.mjs && node scripts/ci-health.test.mjs && node scripts/pin-github-actions.test.mjs && node scripts/validate-workflows.test.mjs && node scripts/release/release-pipeline.test.mjs && node scripts/release/collect-artifacts.test.mjs && node scripts/release/signing-policy.test.mjs && node scripts/secret-scan.test.mjs && node scripts/security/workflow-policy.test.mjs && node scripts/security/validate-client-env.test.mjs && node scripts/security/import-boundaries.test.mjs && node scripts/security/dependency-hardening.test.mjs && bash scripts/test-ci-shell-scripts.sh",
     "bench:canvas": "vitest run --config vitest.bench.config.ts packages/engine/src/bench/replay.bench.ts",
     "bench:table": "vitest run --config vitest.bench.config.ts packages/engine/src/bench/tableReplay.bench.ts",
     "bench:palette": "vitest run --config vitest.bench.config.ts packages/engine/src/bench/paletteExtraction.bench.test.ts",

--- a/scripts/release/collect-artifacts.mjs
+++ b/scripts/release/collect-artifacts.mjs
@@ -22,9 +22,10 @@
  *     --bundle-dir apps/desktop/src-tauri/target/release/bundle \
  *     --out dist/release \
  *     [--os linux] [--arch x86_64]
+ *     [--updater-signatures true|false]
  *
  * Emits into --out:
- *   <renamed artifacts>
+ *   <renamed artifacts> (and updater .sig files when requested)
  *   SHA256SUMS.txt            sha256sum -c compatible
  *   release-manifest.json     consumed by the website download page
  */
@@ -78,7 +79,7 @@ function humanSize(bytes) {
   return mb >= 1000 ? `${(mb / 1000).toFixed(2)} GB` : `${mb.toFixed(1)} MB`;
 }
 
-function collect({ bundleDir, outDir, os, arch, version, product }) {
+function collect({ bundleDir, outDir, os, arch, version, product, updaterSignatures }) {
   if (!existsSync(bundleDir)) {
     throw new Error(
       `Bundle directory not found: ${bundleDir}\n` +
@@ -121,7 +122,7 @@ function collect({ bundleDir, outDir, os, arch, version, product }) {
       // and emits the detached `.sig` beside them. The signature is a release
       // input, not an OS code-signing claim; publish it so the feed can be
       // audited against the exact bytes users download.
-      if (meta.format === 'appimage' || meta.format === 'nsis') {
+      if (updaterSignatures && (meta.format === 'appimage' || meta.format === 'nsis')) {
         copyUpdaterSignature({ source, canonical, outDir });
       }
     }
@@ -137,7 +138,7 @@ function collect({ bundleDir, outDir, os, arch, version, product }) {
       if (!statSync(source).isFile()) continue;
       const canonical = `${product}-${version}-${os}-${arch}.app.tar.gz`;
       copyFileSync(source, join(outDir, canonical));
-      copyUpdaterSignature({ source, canonical, outDir });
+      if (updaterSignatures) copyUpdaterSignature({ source, canonical, outDir });
     }
   }
 
@@ -214,6 +215,7 @@ function main() {
   const currentTarget = targetById(currentTargetId());
   const os = args.os ?? currentTarget.os;
   const arch = args.arch ?? currentTarget.architecture;
+  const updaterSignatures = args['updater-signatures'] !== 'false';
   targetFor(os, arch);
 
   const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')).version;
@@ -227,7 +229,15 @@ function main() {
   // Read from tauri.conf.json rather than hardcoded, so a product rename
   // renames the artifacts too instead of silently shipping the old name.
   const product = productSlug();
-  const artifacts = collect({ bundleDir, outDir, os, arch, version, product });
+  const artifacts = collect({
+    bundleDir,
+    outDir,
+    os,
+    arch,
+    version,
+    product,
+    updaterSignatures,
+  });
   writeChecksums(outDir, artifacts);
   const manifest = writeManifest(outDir, artifacts, version);
 
@@ -238,6 +248,7 @@ function main() {
     );
   }
   process.stdout.write(`\nOutput: ${outDir}\n`);
+  process.stdout.write(`Updater signatures required: ${updaterSignatures ? 'yes' : 'no'}\n`);
   process.stdout.write(`Manifest now lists ${manifest.artifacts.length} artifact(s) total.\n`);
 }
 

--- a/scripts/release/collect-artifacts.test.mjs
+++ b/scripts/release/collect-artifacts.test.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for release artifact collection, including the documented
+ * manual-download fallback when updater signing is not configured.
+ */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '../..');
+const fixture = mkdtempSync(join(tmpdir(), 'varve-collect-artifacts-'));
+const bundle = join(fixture, 'bundle', 'appimage');
+const unsignedOut = join(fixture, 'unsigned');
+const signedOut = join(fixture, 'signed');
+const source = join(bundle, 'Varve_0.1.2_amd64.AppImage');
+
+mkdirSync(bundle, { recursive: true });
+writeFileSync(source, 'synthetic AppImage bytes');
+
+function collect(out, updaterSignatures) {
+  execFileSync(
+    process.execPath,
+    [
+      'scripts/release/collect-artifacts.mjs',
+      '--bundle-dir',
+      join(fixture, 'bundle'),
+      '--out',
+      out,
+      '--os',
+      'linux',
+      '--arch',
+      'x86_64',
+      '--updater-signatures',
+      String(updaterSignatures),
+    ],
+    { cwd: root, stdio: 'pipe' },
+  );
+}
+
+try {
+  collect(unsignedOut, false);
+  assert.equal(existsSync(join(unsignedOut, 'Varve-0.1.2-linux-x86_64.AppImage')), true);
+  assert.equal(existsSync(join(unsignedOut, 'Varve-0.1.2-linux-x86_64.AppImage.sig')), false);
+
+  writeFileSync(`${source}.sig`, 'synthetic updater signature');
+  collect(signedOut, true);
+  assert.equal(existsSync(join(signedOut, 'Varve-0.1.2-linux-x86_64.AppImage.sig')), true);
+
+  rmSync(`${source}.sig`);
+  assert.throws(
+    () => collect(join(fixture, 'missing-signature')),
+    /Missing Tauri updater signature/,
+  );
+  console.log('collect-artifacts tests passed');
+} finally {
+  rmSync(fixture, { recursive: true, force: true });
+}


### PR DESCRIPTION
The release policy documented an unsigned manual-download fallback when platform and updater signing credentials are absent, but release.yml unconditionally required TAURI_SIGNING_PRIVATE_KEY and collect-artifacts unconditionally required updater .sig files.

This PR restores the documented behavior: missing updater key produces a manual-only release without an updater feed; platform signatures remain honest and RELEASE_EXPECT_SIGNED=true remains fail-closed. Adds a fixture test covering unsigned and signed collection paths.

Validation: pnpm test:ci:tools (21 passed), workflow YAML/security validation, collector regression test.