### PR TITLE
fix(release): omit empty updater credentials from unsigned builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,8 +617,6 @@ jobs:
           # for it. Harmless to set everywhere: the Varve binary is stripped by
           # [profile.release] strip = true, and distro libraries ship stripped.
           NO_STRIP: '1'
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VARVE_UPDATE_CHANNEL: ${{ needs.preflight.outputs.channel }}
         run: |
           TAURI_EXTRA_ARGS="--config ${{ github.workspace }}/apps/desktop/src-tauri/tauri.update.channel.json"


### PR DESCRIPTION
## Summary
- remove empty Tauri updater credential variables from the unsigned platform build
- keep platform and updater signing optional when credentials are absent

## Root cause
The unsigned Linux Tauri step exported empty TAURI_SIGNING_PRIVATE_KEY variables. Varve's client-environment guard correctly rejects credential-family variables even when empty, so the build failed before packaging.

## Validation
- pre-commit checks passed
- release tooling and workflow validation passed
- full local gate running against the exact patched content
- failing release run: 31898623172; root cause isolated from job logs