### PR TITLE
fix(release): install AppImage bundler runtime dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,7 +433,7 @@ jobs:
             libfontconfig1-dev libglib2.0-dev libsoup-3.0-dev \
             libgdk-pixbuf2.0-dev libcairo2-dev libpango1.0-dev \
             cmake pkg-config patchelf \
-            squashfs-tools
+            squashfs-tools xdg-utils
 
       - name: Add Rust target
         if: matrix.enabled

--- a/scripts/validate-workflows.test.mjs
+++ b/scripts/validate-workflows.test.mjs
@@ -569,6 +569,12 @@ assert.deepEqual(
     /tests\/e2e\/\(canvas\|settings[\s\S]*shared\|helpers\|fixtures\)[\s\S]*playwright\\\.config\\\.ts/,
     'browser infrastructure paths must select the browser lane',
   );
+  const release = fs.readFileSync('.github/workflows/release.yml', 'utf-8');
+  assert.match(
+    release,
+    /squashfs-tools xdg-utils/,
+    'Linux release bundlers must install xdg-utils for Tauri AppImage packaging',
+  );
   for (const name of ['release.yml', 'website-deploy.yml', 'ci.yml', 'build.yml']) {
     const content = fs.readFileSync(`.github/workflows/${name}`, 'utf-8');
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- install `xdg-utils` in Linux release bundle jobs so Tauri AppImage packaging has `/usr/bin/xdg-open`
- add a workflow regression assertion for the required bundler dependency

## Root cause
The v0.1.2 release run compiled Linux ARM64 successfully but Tauri failed during AppImage bundling because the Ubuntu ARM runner did not provide `xdg-open`.

## Validation
- `node scripts/validate-workflows.test.mjs`
- `node scripts/release/release-pipeline.test.mjs`
- `pnpm test:ci:tools` (21 passed, 0 failed)
- pre-commit checks passed
- `pnpm verify:affected` intentionally escalated because workflow validation changes require the full gate; the release-specific checks above and remote CI are the targeted gates for this dependency-only fix.
