### PR TITLE
fix(release): disable updater signing for manual builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,8 +563,12 @@ jobs:
         if: matrix.enabled
         env:
           CHANNEL: ${{ needs.preflight.outputs.channel }}
+          UPDATER_MODE: ${{ needs.signing-preflight.outputs.updater_mode }}
         run: |
-          node -e "const fs=require('fs'); const c=process.env.CHANNEL; if(!['stable','beta','nightly'].includes(c)) throw new Error('invalid channel'); fs.writeFileSync('apps/desktop/src-tauri/tauri.update.channel.json', JSON.stringify({plugins:{updater:{endpoints:['https://varve.studio/updates/'+c+'.json']}}}, null, 2)+'\\n');"
+          node scripts/release/write-updater-config.mjs \
+            --channel "${CHANNEL}" \
+            --mode "${UPDATER_MODE}" \
+            --output apps/desktop/src-tauri/tauri.update.channel.json
 
       - name: Tauri build (signed platforms)
         if: matrix.enabled && (needs.signing-preflight.outputs.macos_mode == 'signed' || needs.signing-preflight.outputs.windows_mode == 'signed')
@@ -593,6 +597,7 @@ jobs:
           # re-scanned by the artifact scan step below.
           VARVE_SIGNING_STEP_ALLOWED: '1'
           NO_STRIP: '1'
+          VARVE_UPDATER_MODE: ${{ needs.signing-preflight.outputs.updater_mode }}
           VARVE_UPDATE_CHANNEL: ${{ needs.preflight.outputs.channel }}
         run: |
           TAURI_EXTRA_ARGS="--config ${{ github.workspace }}/apps/desktop/src-tauri/tauri.update.channel.json"
@@ -617,6 +622,7 @@ jobs:
           # for it. Harmless to set everywhere: the Varve binary is stripped by
           # [profile.release] strip = true, and distro libraries ship stripped.
           NO_STRIP: '1'
+          VARVE_UPDATER_MODE: ${{ needs.signing-preflight.outputs.updater_mode }}
           VARVE_UPDATE_CHANNEL: ${{ needs.preflight.outputs.channel }}
         run: |
           TAURI_EXTRA_ARGS="--config ${{ github.workspace }}/apps/desktop/src-tauri/tauri.update.channel.json"

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -2,6 +2,9 @@ fn main() {
     if let Ok(channel) = std::env::var("VARVE_UPDATE_CHANNEL") {
         println!("cargo:rustc-env=VARVE_UPDATE_CHANNEL={channel}");
     }
+    if let Ok(mode) = std::env::var("VARVE_UPDATER_MODE") {
+        println!("cargo:rustc-env=VARVE_UPDATER_MODE={mode}");
+    }
     let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let dst = manifest_dir.join("capabilities/wdio.json");
 

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -27,7 +27,16 @@ pub fn update_packaging_context(app: AppHandle) -> UpdatePackagingContext {
     let version = app.package_info().version.to_string();
     let architecture = architecture();
     let channel = channel();
-    let (platform, package_type, authority, location, supported) = detect_runtime();
+    let (platform, package_type, detected_authority, location, detected_supported) =
+        detect_runtime();
+    let (authority, supported) = if updater_enabled() {
+        (detected_authority, detected_supported)
+    } else {
+        // Unsigned/manual releases deliberately omit the updater public key.
+        // Keep the capability unavailable even for writable AppImages so the
+        // frontend never attempts a check that cannot be signature-verified.
+        ("manual-only", false)
+    };
     let build_label = format!("{architecture} {}", package_label(package_type));
     UpdatePackagingContext {
         platform,
@@ -40,6 +49,14 @@ pub fn update_packaging_context(app: AppHandle) -> UpdatePackagingContext {
         runtime_supported: supported,
         build_label,
     }
+}
+
+fn updater_enabled() -> bool {
+    updater_enabled_for_mode(option_env!("VARVE_UPDATER_MODE"))
+}
+
+fn updater_enabled_for_mode(mode: Option<&str>) -> bool {
+    !matches!(mode, Some("manual-only"))
 }
 
 fn architecture() -> &'static str {
@@ -206,13 +223,20 @@ fn directory_writable(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{appimage_capability, package_label};
+    use super::{appimage_capability, package_label, updater_enabled_for_mode};
     use std::fs;
 
     #[test]
     fn package_labels_are_not_os_labels() {
         assert_eq!(package_label("appimage"), "AppImage");
         assert_eq!(package_label("unknown"), "build");
+    }
+
+    #[test]
+    fn manual_only_mode_disables_update_capability() {
+        assert!(!updater_enabled_for_mode(Some("manual-only")));
+        assert!(updater_enabled_for_mode(Some("signed")));
+        assert!(updater_enabled_for_mode(None));
     }
 
     #[test]

--- a/scripts/release/release-pipeline.test.mjs
+++ b/scripts/release/release-pipeline.test.mjs
@@ -17,6 +17,22 @@ import { dirname, join } from 'node:path';
 import { parseChecksums, selectRelease, verifyReleaseIntegrity } from './verify-release-data.mjs';
 import { incrementVersion } from './version.mjs';
 import { buildWebsiteReleaseData, formatCopy } from './website-release-data.mjs';
+import { buildUpdaterConfig } from './write-updater-config.mjs';
+
+// ── updater build-mode configuration ────────────────────────────────────────
+assert.deepEqual(buildUpdaterConfig('stable', 'signed'), {
+  plugins: { updater: { endpoints: ['https://varve.studio/updates/stable.json'] } },
+});
+assert.deepEqual(buildUpdaterConfig('beta', 'manual-only'), {
+  plugins: {
+    updater: {
+      endpoints: ['https://varve.studio/updates/beta.json'],
+      pubkey: null,
+    },
+  },
+});
+assert.throws(() => buildUpdaterConfig('preview', 'signed'), /invalid update channel/);
+assert.throws(() => buildUpdaterConfig('stable', 'unsigned'), /invalid updater mode/);
 
 const runValidator = (files) => {
   try {

--- a/scripts/release/write-updater-config.mjs
+++ b/scripts/release/write-updater-config.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const CHANNELS = new Set(['stable', 'beta', 'nightly']);
+const MODES = new Set(['signed', 'manual-only']);
+
+export function buildUpdaterConfig(channel, mode) {
+  if (!CHANNELS.has(channel)) {
+    throw new Error(`invalid update channel: ${channel}`);
+  }
+  if (!MODES.has(mode)) {
+    throw new Error(`invalid updater mode: ${mode}`);
+  }
+
+  const updater = {
+    endpoints: [`https://varve.studio/updates/${channel}.json`],
+  };
+  if (mode === 'manual-only') {
+    // The base tauri.conf.json contains the public key for signed updater
+    // artifacts. Explicit null removes it from the merged config so Tauri
+    // cannot enter signer mode when the private key is intentionally absent.
+    updater.pubkey = null;
+  }
+  return { plugins: { updater } };
+}
+
+function readOption(args, name) {
+  const index = args.indexOf(name);
+  const value = args[index + 1];
+  if (index < 0 || !value || value.startsWith('--')) {
+    throw new Error(`missing ${name}`);
+  }
+  return value;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const channel = readOption(process.argv.slice(2), '--channel');
+  const mode = readOption(process.argv.slice(2), '--mode');
+  const output = readOption(process.argv.slice(2), '--output');
+  writeFileSync(output, `${JSON.stringify(buildUpdaterConfig(channel, mode), null, 2)}\n`);
+}


### PR DESCRIPTION
## Root cause

Manual/unsigned release builds still inherited the updater public key from `tauri.conf.json`. Because no updater private key is intentionally configured yet, Tauri attempted updater artifact signing after successfully building the Linux bundles and failed.

## Fix

- Generate the channel overlay through a tested release script.
- Set `plugins.updater.pubkey` to `null` for `manual-only` builds so Tauri does not enter updater signer mode.
- Propagate the release updater mode into the native binary.
- Report manual-only builds as update-unsupported so the app remains functional and never attempts an unverifiable update check.
- Keep signed mode unchanged for the future signing rollout.

## Validation

- `node scripts/release/release-pipeline.test.mjs`
- `node scripts/validate-workflows.test.mjs`
- `pnpm test:ci:tools` (21 passed)
- `cargo fmt --all -- --check`
- local `VARVE_UPDATER_MODE=manual-only pnpm tauri build --no-bundle --ci --config ...` passed
- pre-commit release/security/workflow audits passed
