### PR TITLE
fix(release): disable updater artifacts for unsigned bundles

### DIFF
--- a/scripts/release/release-pipeline.test.mjs
+++ b/scripts/release/release-pipeline.test.mjs
@@ -24,11 +24,9 @@ assert.deepEqual(buildUpdaterConfig('stable', 'signed'), {
   plugins: { updater: { endpoints: ['https://varve.studio/updates/stable.json'] } },
 });
 assert.deepEqual(buildUpdaterConfig('beta', 'manual-only'), {
+  bundle: { createUpdaterArtifacts: false },
   plugins: {
-    updater: {
-      endpoints: ['https://varve.studio/updates/beta.json'],
-      pubkey: null,
-    },
+    updater: { endpoints: ['https://varve.studio/updates/beta.json'], active: false, pubkey: '' },
   },
 });
 assert.throws(() => buildUpdaterConfig('preview', 'signed'), /invalid update channel/);

--- a/scripts/release/write-updater-config.mjs
+++ b/scripts/release/write-updater-config.mjs
@@ -17,13 +17,17 @@ export function buildUpdaterConfig(channel, mode) {
   const updater = {
     endpoints: [`https://varve.studio/updates/${channel}.json`],
   };
+  const config = { plugins: { updater } };
   if (mode === 'manual-only') {
-    // The base tauri.conf.json contains the public key for signed updater
-    // artifacts. Explicit null removes it from the merged config so Tauri
-    // cannot enter signer mode when the private key is intentionally absent.
-    updater.pubkey = null;
+    // Tauri's bundler parses the updater key whenever createUpdaterArtifacts
+    // is true. Manual releases must disable artifact generation and provide a
+    // schema-valid inactive updater config; a null/missing pubkey is rejected
+    // by the bundler before it can produce the installer.
+    config.bundle = { createUpdaterArtifacts: false };
+    updater.active = false;
+    updater.pubkey = '';
   }
-  return { plugins: { updater } };
+  return config;
 }
 
 function readOption(args, name) {


### PR DESCRIPTION
## Root cause
The manual-only updater overlay initially removed the public key with `pubkey: null`. That avoided private-key signing, but Tauri's real bundler still requires a schema-valid updater configuration and failed with `missing field pubkey`.

## Fix
- disable `bundle.createUpdaterArtifacts` for manual-only releases
- set the updater plugin inactive with an empty schema-valid `pubkey`
- keep signed mode unchanged for future releases when credentials are available
- retain graceful manual-only runtime behavior; unsigned builds do not advertise or attempt auto-update signatures

## Verification
- real local Tauri `--bundles deb` build produced `Varve_0.1.2_amd64.deb`
- release-pipeline and workflow validation passed
- CI tooling regression suite: 21 passed, 0 failed
- pre-commit checks passed
