### PR TITLE
fix(release): run updater config step with bash on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,6 +561,7 @@ jobs:
 
       - name: Prepare updater channel configuration
         if: matrix.enabled
+        shell: bash
         env:
           CHANNEL: ${{ needs.preflight.outputs.channel }}
           UPDATER_MODE: ${{ needs.signing-preflight.outputs.updater_mode }}


### PR DESCRIPTION
Fixes the Windows release failure in the updater configuration step.

Root cause: the step used Bash backslash continuations while GitHub Actions selected PowerShell on Windows, producing `ParserError: Missing expression after unary operator --`.

Adds `shell: bash` so the existing tested command runs consistently on Windows. Unsigned/manual-only updater policy is unchanged.