### PR TITLE
fix(release): quote publish dispatch choices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,9 @@ on:
         required: false
         default: 'no'
         type: choice
-        options: [no, yes]
+        # Quote these values: YAML 1.1 treats bare `no`/`yes` as booleans,
+        # which makes GitHub reject the documented `publish=yes` dispatch.
+        options: ['no', 'yes']
 
 concurrency:
   # Never cancel a release build in flight — a half-uploaded draft is worse than


### PR DESCRIPTION
Fixes the explicit release publish gate.

GitHub parsed the bare YAML choices `no` and `yes` as booleans, so `gh workflow run ... -f publish=yes` returned HTTP 422. Quoting both choices preserves the documented string input and lets the manual publish job run.

Validation: node scripts/validate-workflows.test.mjs; git diff --check.