### PR TITLE
fix(ci): unblock secret-scan gate, quantize Windows leg, and E2E keyboard-nav firefox/webkit

### DIFF
--- a/.github/workflows/e2e-keyboard-nav.yml
+++ b/.github/workflows/e2e-keyboard-nav.yml
@@ -92,7 +92,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        # Always include chromium: tests/e2e/global-setup.ts warms the vite
+        # dev server with a hardcoded chromium.launch() before any project's
+        # tests run, regardless of --project. On firefox/webkit legs only
+        # the matrix browser was installed, so that warm-up launch failed
+        # with "Executable doesn't exist" and took the whole job down before
+        # a single test ran. `install` is idempotent, so this is a no-op on
+        # the chromium leg.
+        run: npx playwright install --with-deps chromium ${{ matrix.browser }}
       - name: Verify toolchain
         run: |
           node --version

--- a/.github/workflows/quantize.yml
+++ b/.github/workflows/quantize.yml
@@ -270,6 +270,13 @@ jobs:
           python3 -m pip install onnxruntime
 
       - name: Load each bundled model and verify graph metadata
+        # Explicit bash: this step's inline Python uses backslash-escaped
+        # quotes (entry[\"id\"]) that only survive bash's `run:` quoting.
+        # windows-latest defaults to pwsh, whose escaping rules are
+        # different and corrupt the script (`SyntaxError: '[' was never
+        # closed`) before Python ever sees it. Git Bash ships on all three
+        # hosted runner OSes, so this doesn't need per-OS branching.
+        shell: bash
         run: |
           python3 -c "
           import onnxruntime as ort

--- a/scripts/secret-scan.mjs
+++ b/scripts/secret-scan.mjs
@@ -198,7 +198,10 @@ const RULES = [
     id: 'basic-auth-url',
     // Disallow JSON punctuation from the password segment so minified
     // JSON-LD (`"@context":"https://schema.org"... "email":"support@..."`)
-    // does not look like `https://host:password@`.
+    // does not look like a scheme + host + colon + credential + "@" URL.
+    // (No literal example is spelled out here on purpose: this file is
+    // itself part of the tracked tree the scanner walks, and a same-shaped
+    // example in this comment would match this very rule.)
     re: /\bhttps?:\/\/[^\s/:@]+:[^\s/@"',}\]{]{6,}@/g,
   },
   {


### PR DESCRIPTION
## Summary

Three isolated, verified CI infrastructure fixes. Each was root-caused from actual failing GitHub Actions runs on `master` (not guessed from reading YAML).

- **`scripts/secret-scan.mjs`**: the `basic-auth-url` rule's doc comment spelled out a literal example (`` `https://host:password@` ``) that matches the rule's own regex. Since this file is part of the tracked tree the scanner walks, the tracked-tree secret scan has been failing on itself at `scripts/secret-scan.mjs:201` on **every single run** — this is the "Secret scan (tracked tree)" step inside the "Pipeline validation" job that gates `ci.yml`, so it was blocking every push to master and every PR (including every open Dependabot PR) regardless of what else changed. Fixed by describing the shape in prose instead of spelling out a matching literal.
- **`.github/workflows/quantize.yml`**: the `runtime-smoke` job's Windows leg died with `SyntaxError: '[' was never closed`. The inline Python step uses backslash-escaped quotes (`entry[\"id\"]`) that are only valid under bash's `run:` quoting; `windows-latest` defaults to pwsh, which corrupts the script before Python parses it. Added `shell: bash` (Git Bash ships on all three hosted runner OSes).
- **`.github/workflows/e2e-keyboard-nav.yml`**: `tests/e2e/global-setup.ts` warms the vite dev server with a hardcoded `chromium.launch()` before any project's tests run, regardless of `--project`. The `menu-keyboard-nav` job only installed `matrix.browser`, so every firefox/webkit leg of the weekly/dispatch full matrix died in global setup with `Executable doesn't exist ... chrome-headless-shell` before a single test ran. Now installs chromium alongside the matrix browser (`playwright install` is idempotent, so it's a no-op on the chromium leg).

## Evidence

- Secret scan: run [32624186782](https://github.com/K-Arthur/varve/actions/runs/32624186782), job "Pipeline validation (workflow + SHA pins)" — every recent `ci.yml` run on master and every Dependabot PR fails the same way.
- Quantize Windows: run [32698762161](https://github.com/K-Arthur/varve/actions/runs/32698762161), job "Runtime smoke (windows-latest)".
- E2E keyboard nav: run [32700314809](https://github.com/K-Arthur/varve/actions/runs/32700314809), jobs "Menu KB nav (\*/firefox)" and "(\*/webkit)" across all three OSes.

## Not included (flagged, not fixed)

Two more real issues surfaced during this investigation that are **not** CI infrastructure bugs and aren't touched here:

- `Model Supply Chain Validation` → "ONNX graph inspection": `u2netp` and `upscale-realesr-general`'s actual bundled ONNX graphs no longer match the `tensorContract` declared in `apps/desktop/public/models/manifest.json` (different output count/names). This looks like real model-provenance drift the validator is correctly catching — needs a model-owner decision, not a scanner tweak.
- `Model Quantization & Validation` → "Quality validation": `u2netp` and `realesr-general-x4v3` INT8 quantized outputs consistently fail the correlation-loss threshold against FP32 on synthetic inputs (deterministic on both recent scheduled runs). Also a real quality regression, not infra.

Separately: the `Release` workflow's "Verify, attest and finalize" failure (`dist/release/release/...` doubled path) already has a fix in `scripts/release/verify-updater-feed-signatures.mjs` sitting on the `selection/editor-ui` branch (commit `99c288f3`), just not yet merged to master — not duplicated here.

## Test plan

- [x] `node scripts/secret-scan.mjs` exits 0 on the tracked tree
- [x] `node scripts/secret-scan.test.mjs` passes (14 canaries)
- [x] `node scripts/validate-workflows.mjs` — all 10 workflows valid
- [x] `node scripts/pin-github-actions.mjs --check` — all actions pinned
- [x] `pnpm run test:ci:tools` — full CI-tooling battery (23 checks) passes
- [x] Embedded Windows Python step extracted and compiled standalone (`compile()`) to confirm the escaping fix is syntactically correct
- [ ] GitHub-hosted verification: will confirm once this PR's own `ci.yml` run goes green (the secret-scan fix is self-validating — this very PR is the proof)